### PR TITLE
Zfs refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.tox
+__pycache__
+.cache
+*.pyc
+.coverage
+.unit-state.db
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+test:
+	tox
+clean:
+	rm -f */*.pyc
+	rm -rf */__pycache__
+	rm -rf */.cache

--- a/functional_tests/test_zfs.py
+++ b/functional_tests/test_zfs.py
@@ -20,11 +20,11 @@ class TestZfs(unittest.TestCase):
         self.devices = []
         print('Creating files in {0}'.format(self.directory))
         # The command to create multiple images to mount zfs.
-        image = 'dd if=/dev/zero of={0} bs=1M count=150'
+        image = 'dd if=/dev/zero of={0} bs=1024 count=150'
         for a in range(6):
             output_file = '{0}/zfs{1}.img'.format(self.directory, str(a))
             print(image.format(output_file))
-            # Create the files
+            # Create the files to use for storage devices.
             check_call(split(image.format(output_file)))
             self.devices.append(output_file)
         print('File creation complete.')

--- a/functional_tests/test_zfs.py
+++ b/functional_tests/test_zfs.py
@@ -31,38 +31,36 @@ class TestZfs(unittest.TestCase):
 
     def test_adding(self):
         '''Test the init or additive path to create a ZfsPool.'''
-        pool_name = 'test-zfs-pool-1'
-        # Create zfs pool by name.
-        pool = ZfsPool(pool_name)
+        # Create zfs pool with a mount point.
+        pool = ZfsPool(self.mount_point)
         print('Adding the first 3 devices.')
         pool.add(self.devices[0:3])
         print('Adding the last 3 devices.')
         pool.add(self.devices[3:6])
-        assert os.path.isdir('/' + pool_name), 'Mount point does not exist.'
+        assert os.path.isdir(self.mount_point), 'Mount point does not exist.'
         # Run a command that lists the zfs pool pool.
-        cmd = 'sudo zpool list -H {0}'.format(pool_name)
+        cmd = 'sudo zpool list -H {0}'.format(pool.pool_name)
         output = check_output(split(cmd))
         print(output)
-        destroy = 'sudo zpool destroy -f {0}'.format(pool_name)
+        destroy = 'sudo zpool destroy -f {0}'.format(pool.pool_name)
         check_call(split(destroy))
-        print('Pool {0} destroyed.'.format(pool_name))
-        assert pool_name in output.split()[0], 'Pool name not in zfs pool listing.'
+        print('Pool {0} destroyed.'.format(pool.pool_name))
+        assert pool.pool_name in output.split()[0], 'Pool name not in zfs pool listing.'
 
     def test_create(self):
         '''Test the create path to create a ZfsPool.'''
         print('Creating a pool with the first 3 devices.')
         pool = ZfsPool.create(self.mount_point, self.devices[0:3])
         assert os.path.isdir(self.mount_point), 'Mount point does not exist.'
-        pool_name = pool.pool_name
         print('Adding 3 more devices')
         pool.add(self.devices[3:6])
-        cmd = 'sudo zpool list -H {0}'.format(pool_name)
+        cmd = 'sudo zpool list -H {0}'.format(pool.pool_name)
         output = check_output(split(cmd))
         print(output)
-        destroy = 'sudo zpool destroy -f {0}'.format(pool_name)
+        destroy = 'sudo zpool destroy -f {0}'.format(pool.pool_name)
         check_call(split(destroy))
-        print('Pool {0} destroyed.'.format(pool_name))
-        assert(pool_name in output.split()[0], 'Pool name not in zfs pool listing.')
+        print('Pool {0} destroyed.'.format(pool.pool_name))
+        assert pool.pool_name in output.split()[0], 'Pool name not in zfs pool listing.'
 
     def tearDown(self):
         '''Operations run once at the end of the tests.'''

--- a/layer.yaml
+++ b/layer.yaml
@@ -9,3 +9,9 @@ defines:
       This is a build time option for the storage driver to handle the devices
       available to the charm. Only the 'overlay', 'aufs', 'btrfs', and 'zfs'
       are valid at this time.
+  mount-path:
+    type: string
+    default: '/mnt/storage'
+    description: |
+      Default path to mount the storage volume(s) backended by
+      storage_driver

--- a/layer.yaml
+++ b/layer.yaml
@@ -9,9 +9,9 @@ defines:
       This is a build time option for the storage driver to handle the devices
       available to the charm. Only the 'overlay', 'aufs', 'btrfs', and 'zfs'
       are valid at this time.
-  mount-path:
+  mount-point:
     type: string
     default: '/mnt/storage'
     description: |
-      Default path to mount the storage volume(s) backended by
-      storage_driver
+      The absolute path to mount the storage volume(s) backended by
+      storage_driver.

--- a/lib/btrfs.py
+++ b/lib/btrfs.py
@@ -1,0 +1,60 @@
+from subprocess import check_call
+from storage_pool import StoragePool
+
+
+class BtrfsPool(StoragePool):
+    '''The class for a btrfs storage pool.'''
+
+    def __init__(self, reference=None):
+        '''Return an existing BtrfsPool object by string reference name.'''
+        self.reference = reference
+
+    @property
+    def size(self):
+        '''Return a tuple used and total size.'''
+        return self.used, self.total
+
+    @classmethod
+    def create(cls, mountPoint, devices=[], force=False):
+        '''Return a new StoragePool object of devices at the mount point.'''
+        print('BtrfsPool.create()')
+        o = cls()
+        cls.devices = devices
+        cls.mountpoint = mountPoint
+
+        if len(cls.devices) == 2:
+            # Raid1 settings
+            raid_type = 'raid1'
+        elif len(cls.devices) >= 3:
+            # Raid5 settings
+            raid_type = 'raid5'
+        else:
+            # Raid0 settings
+            raid_type = 'raid0'
+
+        cmd = ['mkfs.btrfs', '-f', '-d', raid_type]
+        for dev in cls.devices:
+            cmd.append(dev)
+        # abandon all hope, data of the devices initializing this pool
+        check_call(cmd)
+
+        return o
+
+    def add(self, device, mountPoint):
+        '''Add a device to the btrfs storage pool.'''
+        print('btrfs add')
+        cmd = ['btrfs', 'device', 'add', '-f', device, mountPoint]
+        check_call(cmd)
+
+    def mount(self, device, mountPoint):
+        '''Mount a filesystem.'''
+        print('btrfs mount')
+        # BTRFS doesn't care which disk we choose, so use any identifier from
+        # the btrfs pool to mount the fs
+        mount_cmd = ['mount', '-t', 'btrfs', device[0], mountPoint]
+        check_call(mount_cmd)
+
+    def rebalance(self, mountPoint):
+        print('btrfs rebalance')
+        cmd = ['btrfs', 'balance', mountPoint]
+        check_call(cmd)

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -33,8 +33,9 @@ class ZfsPool(StoragePool):
 
     @classmethod
     def create(cls, mount_point, devices, force=False):
-        '''Return a new ZfsPool object of devices at the mount point. This
-        method actually creates the raidz zfs pool.'''
+        '''Return a new ZfsPool object wiith the specified mount point and
+        list of devices. This method actually creates the raidz zfs pool if
+        it does not already exist.'''
         pool = cls(mount_point)
         pool.add(devices, force)
         return pool
@@ -58,7 +59,7 @@ class ZfsPool(StoragePool):
         the number of disks does not match the original raidz pool.'''
         force_flag = '-f' if force else ''
         # When the pool exists, add devices to the pool.
-        if zfs_pool_exists(self.pool_name):
+        if ZfsPool.exists(self.pool_name):
             # The command that adds a device to a raidz zfs pool.
             cmd = 'sudo zpool add {0} {1} raidz '.format(force_flag,
                                                          self.pool_name)
@@ -78,7 +79,7 @@ class ZfsPool(StoragePool):
             self.devices = devices
 
     @staticmethod
-    def zfs_pool_exists(self, name):
+    def exists(name):
         '''Return True if the specified zfs pool exists, False otherwise.'''
         # The command to list the pool by name.
         cmd = 'sudo zfs list -H {0}'.format(name)

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -31,10 +31,11 @@ class ZfsPool(StoragePool):
         # The mount point must be an absolute path.
         pool.mountpoint = os.path.abspath(mount_point)
         pool.devices = devices
-
+        force_flag = '-f' if force else ''
         # The command that creates a zfs disk pool.
-        cmd = 'sudo zpool create -m -f {0} {1} raidz '.format(pool.mountpoint,
-                                                              pool.pool_name)
+        cmd = 'sudo zpool create -m {0} {1} {2} raidz '.format(force_flag,
+                                                               pool.mountpoint,
+                                                               pool.pool_name)
         cmd += ' '.join(pool.devices)
         print(cmd)
         # Run the command.

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -33,8 +33,8 @@ class ZfsPool(StoragePool):
         pool.devices = devices
 
         # The command that creates a zfs disk pool.
-        cmd = 'sudo zpool create -m {0} {1} raidz '.format(pool.mountpoint,
-                                                           pool.pool_name)
+        cmd = 'sudo zpool create -m -f {0} {1} raidz '.format(pool.mountpoint,
+                                                              pool.pool_name)
         cmd += ' '.join(pool.devices)
         print(cmd)
         # Run the command.

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -1,6 +1,7 @@
 import os
 
 from shlex import split
+from subprocess import call
 from subprocess import check_call
 from subprocess import check_output
 
@@ -8,7 +9,11 @@ from storage_pool import StoragePool
 
 
 class ZfsPool(StoragePool):
-    '''The class to create a zfs storage pool.'''
+    '''The class to create raidz zfs storage pools from a list of devices.
+    The raidz group is a variation on RAID-5 that allows for better
+    distribution of parity and eliminates the "RAID-5 write hole" (in
+    which data and parity become inconsistent after a power loss). Data
+    and parity is striped across all disks within a raidz group.'''
 
     # The devices should be a list of strings.
     devices = []
@@ -16,37 +21,29 @@ class ZfsPool(StoragePool):
     # characters as well as underscore ("_"), dash ("-"), period ("."), colon
     # (":"), and space (" "). The pool names "mirror", "raidz", "spare" and
     # "log" are reserved, as are names beginning with  the  pattern  "c[0-9]".
-    pool_name = 'zfs-storage-pool'
+    pool_name = 'juju-zfs-pool'
     # The mount point has to be an abolute path.
     mountpoint = ''
 
-    def __init__(self, reference):
-        '''Return an ZfsPool object using a specified pool name.'''
-        self.pool_name = reference
+    def __init__(self, mount_point):
+        '''Return an ZfsPool object using the specified mount point. Notice
+        this does not actually create the zfs pool.'''
+        # The mount point must be an absolute path.
+        self.mountpoint = os.path.abspath(mount_point)
 
     @classmethod
     def create(cls, mount_point, devices, force=False):
-        '''Return a new StoragePool object of devices at the mount point.'''
-        pool = cls('zfs-storage-pool')
-        # The mount point must be an absolute path.
-        pool.mountpoint = os.path.abspath(mount_point)
-        pool.devices = devices
-        force_flag = '-f' if force else ''
-        # The command that creates a zfs disk pool.
-        cmd = 'sudo zpool create -m {0} {1} {2} raidz '.format(force_flag,
-                                                               pool.mountpoint,
-                                                               pool.pool_name)
-        cmd += ' '.join(pool.devices)
-        print(cmd)
-        # Run the command.
-        output = check_output(split(cmd))
+        '''Return a new ZfsPool object of devices at the mount point. This
+        method actually creates the raidz zfs pool.'''
+        pool = cls(mount_point)
+        pool.add(devices, force)
         return pool
 
     @property
     def size(self):
-        '''Return a string tuple of used and total size of the storage pool.'''
+        '''Return a string tuple of used and total size of the zfs pool.'''
         # Create a command to get the details of the storage pool (no header).
-        cmd = 'sudo zfs list -H ' + self.pool_name
+        cmd = 'sudo zfs list -H {0}'.format(self.pool_name)
         output = check_output(split(cmd))
         if output:
             # NAME           USED  AVAIL  REFER  MOUNTPOINT
@@ -56,35 +53,34 @@ class ZfsPool(StoragePool):
         # Return a tuple of used and available for this pool.
         return self.used, self.total
 
-    def add(self, devices):
-        '''Add devices to the zfs storage pool. This operation can fail if
-        the number of disks does not match the origin raidz pool.'''
-        # The self.mount_point will only exist if we created the zfs pool.
-        if self.mountpoint:
-            # The command that adds a device to a zfs pool.
-            cmd = 'sudo zpool add {0} raidz '.format(self.pool_name)
+    def add(self, devices, force=False):
+        '''Add devices to a raidz zfs storage pool. This operation can fail if
+        the number of disks does not match the original raidz pool.'''
+        force_flag = '-f' if force else ''
+        # When the pool exists, add devices to the pool.
+        if zfs_pool_exists(self.pool_name):
+            # The command that adds a device to a raidz zfs pool.
+            cmd = 'sudo zpool add {0} {1} raidz '.format(force_flag,
+                                                         self.pool_name)
             cmd += ' '.join(devices)
             print(cmd)
             check_call(split(cmd))
-        else:
-            # The command that creates a zfs pool without a mount point.
-            cmd = 'sudo zpool create -f {0} raidz '.format(self.pool_name)
-            cmd += ' '.join(devices)
-            print(cmd)
-            check_call(split(cmd))
-            self.mountpoint = self.mount_point(self.pool_name)
-        # Append the devices to the device list.
-        if self.devices:
             self.devices.append(devices)
-        else:
+        else:  # The pool does not yet exist, so we must create a new pool.
+            # The command that creates a new raidz zfs disk pool.
+            cmd = 'sudo zpool create {0} -m {1} {2} raidz '.format(
+                    force_flag,
+                    self.mountpoint,
+                    self.pool_name)
+            cmd += ' '.join(devices)
+            print(cmd)
+            output = check_output(split(cmd))
             self.devices = devices
 
-    def mount_point(self, name):
-        '''Return the mount point for the zfs pool name.'''
-        # The command to get the mount_point property from a zfs pool.
-        cmd = 'sudo zfs get -H mountpoint {0}'.format(name)
-        output = check_output(split(cmd))
-        if output:
-            # NAME          PROPERTY    VALUE          SOURCE
-            # mbruzek-pool  mountpoint  /mbruzek-pool  default
-            return output.split()[2]
+    @staticmethod
+    def zfs_pool_exists(self, name):
+        '''Return True if the specified zfs pool exists, False otherwise.'''
+        # The command to list the pool by name.
+        cmd = 'sudo zfs list -H {0}'.format(name)
+        return_code = call(split(cmd))
+        return return_code == 0

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -4,7 +4,7 @@ from shlex import split
 from subprocess import check_call
 from subprocess import check_output
 
-from storagepool import StoragePool
+from storage_pool import StoragePool
 
 
 class ZfsPool(StoragePool):

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -68,7 +68,7 @@ class ZfsPool(StoragePool):
             check_call(split(cmd))
         else:
             # The command that creates a zfs pool without a mount point.
-            cmd = 'sudo zpool create {0} raidz '.format(self.pool_name)
+            cmd = 'sudo zpool create -f {0} raidz '.format(self.pool_name)
             cmd += ' '.join(devices)
             print(cmd)
             check_call(split(cmd))

--- a/lib/zfs.py
+++ b/lib/zfs.py
@@ -21,13 +21,15 @@ class ZfsPool(StoragePool):
     # characters as well as underscore ("_"), dash ("-"), period ("."), colon
     # (":"), and space (" "). The pool names "mirror", "raidz", "spare" and
     # "log" are reserved, as are names beginning with  the  pattern  "c[0-9]".
-    pool_name = 'juju-zfs-pool'
+    pool_name = ''
     # The mount point has to be an abolute path.
     mountpoint = ''
 
-    def __init__(self, mount_point):
+    def __init__(self, mount_point, name='juju-zfs-pool'):
         '''Return an ZfsPool object using the specified mount point. Notice
         this does not actually create the zfs pool.'''
+        # TODO validate/normalize the pool name before proceeding.
+        self.pool_name = name
         # The mount point must be an absolute path.
         self.mountpoint = os.path.abspath(mount_point)
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,16 +1,5 @@
-name: storage
-summary: A layer that uses the storage feature of Juju.
-maintainers:
-    - Matt Bruzek <matthew.bruzek@canonical.com>
-    - Charles Butler <charles.butler@canonical.com>
-description: |
-  A minimalist charm layer that uses Juju storage.
-tags:
-  - infrastructure
-subordinate: false
 storage:
   disk-pool:
     type: block
     multiple:
       range: 0-
-    

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -43,7 +43,7 @@ def install_storage_tools():
         set_state('btrfs-tools-installed')
     if storage_driver == 'zfs':
         lsb_release = host.lsb_release()
-        if lsb_release and lsb_release['Codename'] == 'trusty':
+        if lsb_release and lsb_release['DISTRIB_CODENAME'] == 'trusty':
             configure_sources(update=True,
                               source_var='ppa:zfs-native/stable')
             pkg_list = ['debootstrap', 'spl-dkms', 'zfs-dkms', 'ubuntu-zfs']

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -8,7 +8,8 @@ from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.hookenv import storage_get
 from charmhelpers.core.hookenv import storage_list
 from charmhelpers.fetch import apt_install
-from charmhelpers.fetch import configure_sources
+from charmhelpers.fetch import apt_update
+from charmhelpers.fetch import add_source
 
 
 from charms.reactive import set_state
@@ -42,9 +43,9 @@ def install_storage_tools():
         set_state('btrfs-tools-installed')
     if storage_driver == 'zfs':
         lsb_release = host.lsb_release()
-        if lsb_release and lsb_release['Codename'] == 'trusty':
-            configure_sources(update=True,
-                              source_var='ppa:zfs-native/stable')
+        if lsb_release and lsb_release['DISTRIB_CODENAME'] == 'trusty':
+            add_source('ppa:zfs-native/stable')
+            apt_update(fatal=True)
             pkg_list = ['debootstrap', 'spl-dkms', 'zfs-dkms', 'ubuntu-zfs']
         else:
             pkg_list = ['zfsutils-linux']

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -16,7 +16,6 @@ from charms.reactive import hook
 from charms.reactive import when
 from charms.reactive import when_not
 
-from btrfs import BtrfsPool
 from zfs import ZfsPool
 
 from charms import layer
@@ -100,7 +99,7 @@ def add_mounted_devices(devices):
 
 def get_storage_driver():
     '''Get the storage-driver for this layer.'''
-    layer_options = layer.options('docker')
+    layer_options = layer.options('storage')
     return layer_options['storage-driver']
 
 

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -74,8 +74,9 @@ def handle_btrfs_pool():
 def handle_zfs_pool():
     '''The zfs tools are installed, use the zfs tools.'''
     unmounted_devices = get_unmounted_devices()
+    number_of_devices = len(unmounted_devices)
     # Since we are using raidz you must add devices in multiples of 3.
-    if len(unmounted_devices) % 3 == 0:
+    if number_of_devices > 0 and number_of_devices % 3 == 0:
         zfs = ZfsPool('juju-zfs-pool')
         zfs.add(unmounted_devices)
         add_mounted_devices(unmounted_devices)

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -11,7 +11,7 @@ from charmhelpers.fetch import apt_install
 from charmhelpers.fetch import apt_update
 from charmhelpers.fetch import add_source
 
-
+from charms.reactive import remove_state
 from charms.reactive import set_state
 from charms.reactive import hook
 from charms.reactive import when
@@ -76,9 +76,7 @@ def handle_zfs_pool():
     unmounted_devices = get_unmounted_devices()
     # Since we are using raidz you must add devices in multiples of 3.
     if len(unmounted_devices) % 3 == 0:
-        mount_path = get_mount_path()
-
-        zfs = ZfsPool(mount_path, 'juju-zfs-pool', True)
+        zfs = ZfsPool('juju-zfs-pool')
         zfs.add(unmounted_devices)
         add_mounted_devices(unmounted_devices)
     remove_state('disk-pool-storage-attached')

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -1,10 +1,5 @@
-import os
-from subprocess import check_call
-
 from charmhelpers.core import host
 from charmhelpers.core import unitdata
-from charmhelpers.core.hookenv import config
-from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.hookenv import storage_get
 from charmhelpers.core.hookenv import storage_list
 from charmhelpers.fetch import apt_install
@@ -18,6 +13,7 @@ from charms.reactive import when
 from charms.reactive import when_not
 
 from zfs import ZfsPool
+from btrfs import BtrfsPool
 
 from charms import layer
 

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -57,7 +57,7 @@ def install_storage_tools():
 @when('disk-pool-storage-attached', 'btrfs-tools-installed')
 def handle_btrfs_pool():
     '''The btrfs tools are installed, use the btfs tools.'''
-    mount_path = '/var/lib/docker'
+    mount_path = get_mount_path()
     devices = get_devices()
     try:
         bfs = BtrfsPool(mount_path)
@@ -103,6 +103,10 @@ def get_storage_driver():
     layer_options = layer.options('storage')
     return layer_options['storage-driver']
 
+def get_mount_path():
+    '''Get the storage-driver for this layer.'''
+    layer_options = layer.options('storage')
+    return layer_options['mount-path']
 
 def get_devices():
     '''Get a list of storage devices.'''

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -83,9 +83,9 @@ def handle_zfs_pool():
 
 def get_unmounted_devices():
     '''Return a list of devices that are not yet mounted.'''
-    device_set = {get_devices()}
+    device_set = set(get_devices())
     kv_store = unitdata.kv()
-    mounted_set = {kv_store.get('mounted.devices') or []}
+    mounted_set = set(kv_store.get('mounted.devices') or [])
     return list(device_set - mounted_set)
 
 

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -58,15 +58,15 @@ def install_storage_tools():
 @when('disk-pool-storage-attached', 'btrfs-tools-installed')
 def handle_btrfs_pool():
     '''The btrfs tools are installed, use the btfs tools.'''
-    mount_path = get_mount_path()
+    mount_point = get_mount_point()
     devices = get_devices()
     try:
-        bfs = BtrfsPool(mount_path)
+        bfs = BtrfsPool(mount_point)
         for dev in devices:
             bfs.add(dev)
     except OSError:
-        bfs = BtrfsPool.create(mountPoint=mount_path, devices=devices)
-        bfs.mount(devices[0], mount_path)
+        bfs = BtrfsPool.create(mountPoint=mount_point, devices=devices)
+        bfs.mount(devices[0], mount_point)
     remove_state('disk-pool-storage-attached')
 
 
@@ -75,10 +75,10 @@ def handle_zfs_pool():
     '''The zfs tools are installed, use the zfs tools.'''
     unmounted_devices = get_unmounted_devices()
     number_of_devices = len(unmounted_devices)
-    mount_path = get_mount_path()
+    mount_point = get_mount_point()
     # Since we are using raidz you must add devices in multiples of 3.
     if number_of_devices > 0 and number_of_devices % 3 == 0:
-        zfs = ZfsPool(mount_path)
+        zfs = ZfsPool(mount_point)
         # Mount the devices in zfs.
         zfs.add(unmounted_devices, True)
         # Add the devices to the charm k/v store so we don't mount them again.
@@ -114,10 +114,10 @@ def get_storage_driver():
     return layer_options['storage-driver']
 
 
-def get_mount_path():
+def get_mount_point():
     '''Get the storage-driver for this layer.'''
     layer_options = layer.options('storage')
-    return layer_options['mount-path']
+    return layer_options['mount-point']
 
 
 def get_devices():

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -1,12 +1,15 @@
 import os
 from subprocess import check_call
 
+from charmhelpers.core import host
 from charmhelpers.core import unitdata
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.hookenv import storage_get
 from charmhelpers.core.hookenv import storage_list
 from charmhelpers.fetch import apt_install
+from charmhelpers.fetch import configure_sources
+
 
 from charms.reactive import set_state
 from charms.reactive import hook
@@ -39,7 +42,13 @@ def install_storage_tools():
         apt_install(pkg_list, fatal=True)
         set_state('btrfs-tools-installed')
     if storage_driver == 'zfs':
-        pkg_list = ['zfsutils-linux']
+        lsb_release = host.lsb_release()
+        if lsb_release and lsb_release['Codename'] == 'trusty':
+            configure_sources(update=True,
+                              source_var='ppa:zfs-native/stable')
+            pkg_list = ['debootstrap', 'spl-dkms', 'zfs-dkms', 'ubuntu-zfs']
+        else:
+            pkg_list = ['zfsutils-linux']
         apt_install(pkg_list, fatal=True)
         set_state('zfs-tools-installed')
     set_state('disk-pool-tools-installed')

--- a/reactive/storage.py
+++ b/reactive/storage.py
@@ -21,6 +21,7 @@ from zfs import ZfsPool
 
 from charms import layer
 
+
 @hook('disk-pool-storage-attached')
 def storage_attached():
     '''Run every time storage is attached to the charm.'''
@@ -75,7 +76,9 @@ def handle_zfs_pool():
     unmounted_devices = get_unmounted_devices()
     # Since we are using raidz you must add devices in multiples of 3.
     if len(unmounted_devices) % 3 == 0:
-        zfs = ZfsPool('juju-zfs-pool')
+        mount_path = get_mount_path()
+
+        zfs = ZfsPool(mount_path, 'juju-zfs-pool', True)
         zfs.add(unmounted_devices)
         add_mounted_devices(unmounted_devices)
     remove_state('disk-pool-storage-attached')
@@ -103,10 +106,12 @@ def get_storage_driver():
     layer_options = layer.options('storage')
     return layer_options['storage-driver']
 
+
 def get_mount_path():
     '''Get the storage-driver for this layer.'''
     layer_options = layer.options('storage')
     return layer_options['mount-path']
+
 
 def get_devices():
     '''Get a list of storage devices.'''

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = py27
+skipsdist = True
+
+[testenv]
+install_command = pip install {opts} --pre --use-wheel {packages}
+deps =
+    flake8
+    pytest
+    mock
+
+setenv =
+    PYTHONPATH = {toxinidir}/lib
+
+commands =
+    flake8 reactive/
+    py.test functional_tests/
+    py.test unit_tests/


### PR DESCRIPTION
Sorry for the excessive commits, it was an iterative process, but here is the gist:  
- I added tox.ini for tests and a Makefile to clean up after tests.
- Changed the ZfsPool class to always require a mount point.
- Re-factored the ZfsPool class to use the add method to add or create pools.
- Added back in the missing BtrfsPool class.
- Added comments in storage.py and fixed the logic to work with the ZfsPool class.

This has been tested successfully on juju 1.25 using Amazon. Running tox now lints and runs both tests which all pass.
